### PR TITLE
timeafter: skip check on Go ≥ 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.22.0
 
 require (
 	golang.org/x/exp v0.0.0-20230809094429-853ea248256d
+	golang.org/x/mod v0.21.0
 	golang.org/x/tools v0.26.0
 )
 
-require (
-	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
-)
+require golang.org/x/sync v0.8.0 // indirect

--- a/timeafter/doc.go
+++ b/timeafter/doc.go
@@ -2,7 +2,7 @@
 // Copyright Authors of Cilium
 
 // Package timeafter defines an Analyzer that checks for the use of time.After
-// in loops.
+// in loops on Go versions before 1.23
 //
 // # Analyzer timeafter
 //


### PR DESCRIPTION
Go version ≥ 1.23 no longer has the issue of not collecting unstopped Timers and time.After can safely be used in loops. Also see https://go.dev/doc/go1.23#timer-changes and
https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/time/sleep.go;l=196-201

Thus we can skip the timeafter check on modules with go.mod specifying go1.23 or later.

Example run:

```
$ mkdir timeafter && cd timeafter
$ cat <<EOF > main.go
package main

import "time"

func main() {
	for {
		select {
		case <-time.After(5 * time.Second):
		}
	}
}
$ cat <<EOF > go.mod
module timeafter

go 1.22.0
EOF
$ linters .
/home/tklauser/tmp/timeafter/main.go:8:10: use of time.After in a for loop is prohibited, use inctimer instead
$ sed -ie 's/go 1\.22\.0/go 1.23.0/' go.mod
$ linters .
$
```