### PR TITLE
Skip linters early if affected package is not imported

### DIFF
--- a/analysisutil/util.go
+++ b/analysisutil/util.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package analysisutil defines helper functions used by more than one linters.
+package analysisutil
+
+import "go/types"
+
+// ImportsPackage reports whether path is imported by pkg.
+//
+// Copied from
+// golang.org/x/tools/go/analysis/passes/internal/analysisutil.Imports.
+func ImportsPackage(pkg *types.Package, path string) bool {
+	for _, imp := range pkg.Imports() {
+		if imp.Path() == path {
+			return true
+		}
+	}
+	return false
+}

--- a/ioreadall/io_readall.go
+++ b/ioreadall/io_readall.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
+
+	"github.com/cilium/linters/analysisutil"
 )
 
 const (
@@ -37,6 +39,10 @@ func init() {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
+	if !analysisutil.ImportsPackage(pass.Pkg, "io") {
+		return nil, nil // doesn't directly import io package
+	}
+
 	inspct, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, errors.New("analyzer is not type *inspector.Inspector")

--- a/slowg/slowg.go
+++ b/slowg/slowg.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 	"golang.org/x/tools/go/types/typeutil"
+
+	"github.com/cilium/linters/analysisutil"
 )
 
 // Analyzer implements an analysis function that checks for inappropriate use
@@ -26,6 +28,11 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (any, error) {
+	if !analysisutil.ImportsPackage(pass.Pkg, "log/slog") &&
+		!analysisutil.ImportsPackage(pass.Pkg, "golang.org/x/exp/slog") {
+		return nil, nil // doesn't directly import slog package
+	}
+
 	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, errors.New("require analyzer of type *inspector.Inspector")

--- a/timeafter/time_after.go
+++ b/timeafter/time_after.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
+
+	"github.com/cilium/linters/analysisutil"
 )
 
 const (
@@ -46,6 +48,10 @@ func (v visitor) Visit(node ast.Node) ast.Visitor {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
+	if !analysisutil.ImportsPackage(pass.Pkg, "time") {
+		return nil, nil // doesn't directly import time package
+	}
+
 	inspct, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, errors.New("analyzer is not type *inspector.Inspector")


### PR DESCRIPTION
Skip the ioreadall, slowg and timeafter linters early if the respective packages they check for (i.e. io, slog/log, golang.org/x/exp/slog and time) is not imported by the package that is currently analyzed. This should reduce linter run time a bit on packages that don't import any of the checked packages.